### PR TITLE
Improve microphone example

### DIFF
--- a/MicrophoneExample/Microphone/BlockingStream.cs
+++ b/MicrophoneExample/Microphone/BlockingStream.cs
@@ -18,30 +18,11 @@ namespace Speechmatics.Realtime.Microphone
             _blocks = new BlockingCollection<byte[]>(streamWriteCountCache);
         }
 
-        public override bool CanTimeout
-        {
-            get { return false; }
-        }
-
-        public override bool CanRead
-        {
-            get { return true; }
-        }
-
-        public override bool CanSeek
-        {
-            get { return false; }
-        }
-
-        public override bool CanWrite
-        {
-            get { return true; }
-        }
-
-        public override long Length
-        {
-            get { throw new NotSupportedException(); }
-        }
+        public override bool CanTimeout => false;
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
 
         public override void Flush()
         {
@@ -52,8 +33,8 @@ namespace Speechmatics.Realtime.Microphone
 
         public override long Position
         {
-            get { throw new NotSupportedException(); }
-            set { throw new NotSupportedException(); }
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -129,13 +110,13 @@ namespace Speechmatics.Realtime.Microphone
         private static void ValidateBufferArgs(byte[] buffer, int offset, int count)
         {
             if (buffer == null)
-                throw new ArgumentNullException("buffer");
+                throw new ArgumentNullException(nameof(buffer));
             if (offset < 0)
-                throw new ArgumentOutOfRangeException("offset");
+                throw new ArgumentOutOfRangeException(nameof(offset));
             if (count < 0)
-                throw new ArgumentOutOfRangeException("count");
+                throw new ArgumentOutOfRangeException(nameof(count));
             if (buffer.Length - offset < count)
-                throw new ArgumentException("buffer.Length - offset < count");
+                throw new ArgumentException($"{nameof(buffer)}.Length - {nameof(offset)} < {nameof(count)}");
         }
     }
 }

--- a/MicrophoneExample/Microphone/Program.cs
+++ b/MicrophoneExample/Microphone/Program.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using NAudio.CoreAudioApi;
 using NAudio.Wave;
@@ -12,42 +14,76 @@ namespace Speechmatics.Realtime.Microphone
 {
     public class Program
     {
-        private static readonly BlockingStream AudioStream = new BlockingStream(1024*1024*10);
-
+        private static bool IsStereo;
+        private static readonly BlockingStream AudioStream = new BlockingStream(1024*1024);
         private static string ToJson(object obj)
         {
             return JsonConvert.SerializeObject(obj);
         }
 
-        private static string RtUrl => "wss://staging.realtimeappliance.speechmatics.io:9000/v2";
+        // private static string RtUrl => "wss://staging.realtimeappliance.speechmatics.io:9000/v2";
+        private static string RtUrl => "ws://192.168.128.30:9000/v2";
+
+        private static MMDevice ChooseDevice()
+        {
+            var devices = new MMDeviceEnumerator().EnumerateAudioEndPoints(DataFlow.Capture, DeviceState.Active);
+            Console.WriteLine("Detected devices - enter selection");
+            int idx = 1;
+            foreach (var dev in devices)
+            {
+                Console.WriteLine($"{idx++}) {dev}");
+            }
+            Console.WriteLine();
+
+            while (true)
+            {
+                var input = Console.ReadLine();
+                try
+                {
+                    var choice = Int32.Parse(input);
+                    return devices[choice - 1];
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+            }
+        }
 
         // ReSharper disable once UnusedParameter.Local
         public static void Main(string[] args)
         {
+            // NAudio has two (three?) audio capture APIs
+
+            // This is the first one I tried, but apparently the wasapi one is lower level and 
+            // therefore better.
+            //
+            // var waveSource = new WaveInEvent {WaveFormat = new WaveFormat(44100, 16, 1)};
+            // This is an example, but experiment shows that making the value too low will
+            // result in incomplete buffers to send to the RT appliance, leading to bad
+            // transcripts.
+            // waveSource.BufferMilliseconds = 100;
+            // waveSource.DataAvailable += WaveSourceOnDataAvailable;
+            // waveSource.StartRecording();
+
+            var selectedDevice = ChooseDevice();
+
+            var wasapiClient = new WasapiCapture(selectedDevice);
+            var sampleRate = wasapiClient.WaveFormat.SampleRate;
+            var channels = wasapiClient.WaveFormat.Channels;
+
+            IsStereo = channels == 2;
+
+            Console.WriteLine("Sample rate {0}", sampleRate);
+            Console.WriteLine("Bits per sample {0}", wasapiClient.WaveFormat.BitsPerSample);
+            Console.WriteLine("Channels {0}", channels);
+            Console.WriteLine("Encoding {0}", wasapiClient.WaveFormat.Encoding);
+            wasapiClient.DataAvailable += WaveSourceOnDataAvailable;
+
             var t = new Task(() =>
             {
-                // NAudio has two audio capture APIs
-
-                // This is the first one I tried, but apparently the wasapi one is lower level and 
-                // therefore better.
-                //
-                // var waveSource = new WaveInEvent {WaveFormat = new WaveFormat(44100, 16, 1)};
-                // This is an example, but experiment shows that making the value too low will
-                // result in incomplete buffers to send to the RT appliance, leading to bad
-                // transcripts.
-                // waveSource.BufferMilliseconds = 100;
-                // waveSource.DataAvailable += WaveSourceOnDataAvailable;
-                // waveSource.StartRecording();
-
-                var wasapiClient = new WasapiCapture();
-                Debug.WriteLine("Sample rate {0}", wasapiClient.WaveFormat.SampleRate);
-                Debug.WriteLine("Bits per sample {0}", wasapiClient.WaveFormat.BitsPerSample);
-                Debug.WriteLine("Channels {0}", wasapiClient.WaveFormat.Channels);
-                Debug.WriteLine("Encoding {0}", wasapiClient.WaveFormat.Encoding);
-                wasapiClient.DataAvailable += WaveSourceOnDataAvailable;
                 wasapiClient.StartRecording();
             });
-            t.Start();
 
             using (var stream = AudioStream)
             {
@@ -59,20 +95,24 @@ namespace Speechmatics.Realtime.Microphone
                      */
 
                     // Make sure the sampleRate matches the value in the wasapiClient object
-                    var config = new SmRtApiConfig("en", 16000, AudioFormatType.Raw, AudioFormatEncoding.PcmF32Le)
+                    var config = new SmRtApiConfig("en", sampleRate, AudioFormatType.Raw, AudioFormatEncoding.PcmF32Le)
                     {
                         AddTranscriptCallback = Console.Write,
                         // AddPartialTranscriptMessageCallback = s => Console.Write("* " + s.transcript),
                         ErrorMessageCallback = s => Console.WriteLine(ToJson(s)),
                         WarningMessageCallback = s => Console.WriteLine(ToJson(s)),
                         Insecure = true,
-                        BlockSize = 16384
+                        BlockSize = 8192
                     };
 
                     var api = new SmRtApi(RtUrl,
                         stream,
                         config
                     );
+
+                    // Start recording audio
+                    t.Start();
+
                     // Run() will block until the transcription is complete.
                     Console.WriteLine($"Connecting to {RtUrl}");
                     api.Run();
@@ -87,9 +127,49 @@ namespace Speechmatics.Realtime.Microphone
             Console.ReadLine();
         }
 
+        /// <summary>
+        /// We want to turn the 2 streams into 1.
+        /// </summary>
+        /// <param name="waveInEventArgs"></param>
+        /// <returns></returns>
+        private static byte[] SquashStereo(WaveInEventArgs waveInEventArgs)
+        {
+            var data = waveInEventArgs.Buffer;
+            // TODO: do not allocate a block every time this is called
+            var audioBytes = new byte[waveInEventArgs.BytesRecorded / 2];
+            // offset into the receiving buffer
+            var offset = 0;
+
+            for (var i = 0; i < waveInEventArgs.BytesRecorded; i += 8)
+            {
+                var s = BitConverter.ToSingle(data, i) / 2.0f + BitConverter.ToSingle(data, i + 4) / 2.0f;
+                Buffer.BlockCopy(BitConverter.GetBytes(s), 0, audioBytes, offset, 4);
+                offset += 4;
+            }
+
+            return audioBytes;
+        }
+
         private static void WaveSourceOnDataAvailable(object sender, WaveInEventArgs waveInEventArgs)
         {
-            AudioStream.Write(waveInEventArgs.Buffer, 0, waveInEventArgs.BytesRecorded);
+
+            // Use this code to save the audio to a .raw file to examine in Audacity
+            //
+            //using (var f = File.OpenWrite("./audio.raw"))
+            //{
+            //    f.Seek(0, SeekOrigin.End);
+            //    f.Write(waveInEventArgs.Buffer, 0, waveInEventArgs.BytesRecorded);
+            //    //f.Write(squashed, 0, squashed.Length);
+            //}
+            if (IsStereo)
+            {
+                var squashed = SquashStereo(waveInEventArgs);
+                AudioStream.Write(squashed, 0, squashed.Length);
+            }
+            else
+            {
+                AudioStream.Write(waveInEventArgs.Buffer, 0, waveInEventArgs.BytesRecorded);
+            }
         }
     }
 }


### PR DESCRIPTION
The real microphone (not Virtual Audio Cable, the fake microphone) is _stereo_ so to work with the RTA it needs to be crushed down to a mono stream.

We do this in the obvious way, by averaging the samples of the left and right channels.

There's also some debugging stuff to select the input device, so you can tell if (say) the encoding isn't   32-bit floating point.